### PR TITLE
no dflags

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -9,7 +9,6 @@ excludedSourceFiles "src/thrift/index.d"
 sourcePaths "src"
 importPaths "src"
 targetType "library"
-dflags "-i" "-Isrc"
 version "~master"
 
 configuration "default" {


### PR DESCRIPTION
These 2 cause absolute havok to builds as they are infectious to anyone who depends on thrift-d